### PR TITLE
Fix specs to use random ordering

### DIFF
--- a/spec/models/spree/stock/splitter/base_spec.rb
+++ b/spec/models/spree/stock/splitter/base_spec.rb
@@ -8,8 +8,8 @@ module Spree
         let(:stock_location) { mock_model(Spree::StockLocation) }
 
         it 'continues to splitter chain' do
-          splitter1 = Base.new(stock_location)
-          splitter2 = Base.new(stock_location, splitter1)
+          splitter1 = Spree::Stock::Splitter::Base.new(stock_location)
+          splitter2 = Spree::Stock::Splitter::Base.new(stock_location, splitter1)
           packages = []
 
           expect(splitter1).to receive(:split).with(packages)
@@ -17,7 +17,9 @@ module Spree
         end
 
         it 'accepts a packer (deprecated)' do
-          splitter = Spree::Deprecation.silence { Base.new(packer) }
+          splitter = Spree::Deprecation.silence do
+            Spree::Stock::Splitter::Base.new(packer)
+          end
 
           expect(splitter.stock_location).to eq(packer.stock_location)
         end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -59,4 +59,5 @@ RSpec.configure do |config|
   end
 
   config.fail_fast = ENV['FAIL_FAST'] || false
+  config.order = :random
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -34,6 +34,13 @@ RSpec.configure do |config|
   # to setup a test will be unavailable to the browser, which runs under a separate server instance.
   config.use_transactional_fixtures = false
 
+  # Reset our application preferences before each example
+  # This is necessary for tests that set the `track_inventory_levels` preference
+  config.before :each do
+    Spree::Config.instance_variables.each { |iv| Spree::Config.remove_instance_variable(iv) }
+    Spree::Config.preference_store = Spree::Config.default_preferences
+  end
+
   # Ensure Suite is set to use transactions for speed.
   config.before :suite do
     DatabaseCleaner.strategy = :transaction

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,14 +8,6 @@ RSpec.configure do |config|
   # Infer an example group's spec type from the file location.
   config.infer_spec_type_from_file_location!
 
-  # == URL Helpers
-  #
-  # Allows access to Spree's routes in specs:
-  #
-  # visit spree.admin_path
-  # current_path.should eql(spree.products_path)
-  config.include Spree::TestingSupport::UrlHelpers
-
   # == Mock Framework
   #
   # If you prefer to use mocha, flexmock or RR, uncomment the appropriate line:
@@ -25,14 +17,6 @@ RSpec.configure do |config|
   # config.mock_with :rr
   config.mock_with :rspec
   config.color = true
-
-  # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
-  config.fixture_path = "#{::Rails.root}/spec/fixtures"
-
-  # Capybara javascript drivers require transactional fixtures set to false, and we use DatabaseCleaner
-  # to cleanup after each test instead.  Without transactional fixtures set to false the records created
-  # to setup a test will be unavailable to the browser, which runs under a separate server instance.
-  config.use_transactional_fixtures = false
 
   # Reset our application preferences before each example
   # This is necessary for tests that set the `track_inventory_levels` preference


### PR DESCRIPTION
The specs were failing when run randomly because the `Packer` spec was setting the `track_inventory_levels` preference to false and it was never being reset to its default value.

This PR also moves to using explicit naming in the `Splitter::Base` spec and removes some unnecessary settings related to Capybara/UI testing from the spec_helper.

