### PR TITLE
Tell Travis to test against all Solidus >= v2.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,11 @@
 sudo: false
 cache: bundler
 language: ruby
-bundler_args: --quiet
-script:
-  - bundle exec rake
 rvm:
-  - 2.1.5
+  - 2.3.1
+env:
+  matrix :
+    - SOLIDUS_BRANCH=v2.4 DB=postgres
+    - SOLIDUS_BRANCH=master DB=postgres
+    - SOLIDUS_BRANCH=v2.4 DB=mysql
+    - SOLIDUS_BRANCH=master DB=mysql

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'solidus', github: 'solidusio/solidus'
+branch = ENV.fetch('SOLIDUS_BRANCH', 'master')
+gem 'solidus', github: 'solidusio/solidus', branch: branch
 
 gemspec

--- a/solidus_legacy_stock_system.gemspec
+++ b/solidus_legacy_stock_system.gemspec
@@ -16,8 +16,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*", 'LICENSE', 'Rakefile', 'README.md']
   s.test_files = Dir['test/**/*']
 
-  s.add_dependency 'solidus'
-  s.add_dependency 'solidus_core'
+  s.add_dependency 'solidus_core', ['>= 2.4.x', '< 3.x']
 
   s.add_development_dependency 'database_cleaner'
   s.add_development_dependency 'factory_girl'

--- a/solidus_legacy_stock_system.gemspec
+++ b/solidus_legacy_stock_system.gemspec
@@ -29,4 +29,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rubocop-rspec', '1.4.0'
   s.add_development_dependency 'simplecov'
   s.add_development_dependency 'sqlite3'
+  s.add_development_dependency 'pg'
+  s.add_development_dependency 'mysql2'
 end


### PR DESCRIPTION
**EDIT**: This PR also specifies `solidus_core` as the runtime dependency. This extension doesn't need all of Solidus, just the models.