### PR TITLE
Stop looking for decorator files to load

### DIFF
--- a/lib/solidus_legacy_stock_system/engine.rb
+++ b/lib/solidus_legacy_stock_system/engine.rb
@@ -12,13 +12,5 @@ module SolidusLegacyStockSystem
     config.generators do |g|
       g.test_framework :rspec
     end
-
-    def self.activate
-      Dir.glob(File.join(File.dirname(__FILE__), '../../app/**/*_decorator*.rb')) do |c|
-        Rails.configuration.cache_classes ? require(c) : load(c)
-      end
-    end
-
-    config.to_prepare(&method(:activate).to_proc)
   end
 end


### PR DESCRIPTION
This extension doesn't use any decorator files. These engine related
lines were breaking code coverage.